### PR TITLE
build-distro.sh fails when finalizing ISO into artifact

### DIFF
--- a/build-distro.sh
+++ b/build-distro.sh
@@ -76,7 +76,13 @@ if [ -n "${WORKSPACE}" ] ; then
   PKG_RELEASE_BASE="${WORKSPACE}/artifact-pkg-base"
 else
   #Create/use an artifacts dir in the current dir
-  ARTIFACTS_DIR="${CURDIR}/artifact-iso"
+  if [ $CURDIR == "." ] ; then
+      artifactDir=`readlink -f $CURDIR`
+  else
+      artifactDir="$CURDIR"	  
+  fi 	  
+  ARTIFACTS_DIR="${artifactDir}/artifact-iso"
+
   PKG_RELEASE_PORTS="${CURDIR}/artifact-pkg"
   PKG_RELEASE_BASE="${CURDIR}/artifact-pkg-base"
 fi
@@ -471,6 +477,7 @@ make_release(){
   else
     ISOBASE=`basename -s ".json" "${TRUEOS_MANIFEST}"`
   fi
+
   local ISONAME="${ISOBASE}-${CURDATE}"
 
   #Remove old artifacts (if any)
@@ -488,6 +495,7 @@ make_release(){
     rm *.iso
   fi
   cd "${BASEDIR}/release"
+
   make release
   if [ $? -eq 0 ] ; then
     cd "${INTERNAL_RELEASE_DIR}"


### PR DESCRIPTION
Fixed issue of creating ISO from current working directory trident-build checkout when ./artifact-iso is not found due to relative path being used after script cd'ed into <obj root>release/ directory

ISO located here:
`+++++ pwd [/usr/obj/usr/src_tmp/amd64.amd64/release]
`
...
...
...
Target artifact-iso directory is searched here and script fails:
`
cp: directory ./artifact-iso does not exist
[WARNING] ISO files not found in dir: /usr/obj/usr/src_tmp/amd64.amd64/release
cp: ./artifact-iso/tar is not a directory
[WARNING] TXZ files not found in dir: /usr/obj/usr/src_tmp/amd64.amd64/release
cp: directory ./artifact-iso/tar does not exist
[WARNING] MANIFEST file not found in dir: /usr/obj/usr/src_tmp/amd64.amd64/release
ls: ./artifact-iso: No such file or directory
`