### PR TITLE
[trident-build] Issue #6: Fixed the issue of CLI manifest option not overriding manifest for ISO

### DIFF
--- a/build-distro.sh
+++ b/build-distro.sh
@@ -36,7 +36,7 @@ if [ ! -f "${TRUEOS_MANIFEST}" ] ; then
   echo "[ERROR] Specified manifest cannot be found: ${TRUEOS_MANIFEST}"
   return 1
 fi
-TRUEOS_MANIFEST=`realpath -q "${TRUEOS_MANIFEST}"`
+export TRUEOS_MANIFEST=`realpath -q "${TRUEOS_MANIFEST}"`
 
 #Perform any directory replacements in the manifest as needed
 grep -q "%%PWD%%" "${TRUEOS_MANIFEST}"


### PR DESCRIPTION
Before the fix:
>  +++++ manifest [/export/data/max/trident-build/trident-master.json]
> Replacing PWD paths in TrueOS Manifest...
> [INFO] Building ISO...
> rm: *.iso: No such file or directory
> make -C /usr/src_tmp/release  obj
> make -C /usr/src_tmp/release  ftp cdrom
> `ftp' is up to date.
> env SRCDIR=/usr/src_tmp/release/..  OBJDIR=/usr/obj/usr/src_tmp/amd64.amd64/release  >TRUEOS_MANIFEST=/usr/src_tmp/release/../release/trueos-manifest.json

After the fix:
> +++++ manifest [/export/data/max/trident-build/trident-master.json]
> [INFO] Building ISO...
> rm: *.iso: No such file or directory
> make -C /usr/src_tmp/release  obj
> make -C /usr/src_tmp/release  ftp cdrom
> `ftp' is up to date.
> env SRCDIR=/usr/src_tmp/release/..  OBJDIR=/usr/obj/usr/src_tmp/amd64.amd64/release  TRUEOS_MANIFEST=/export/data/max/trident-build/trident-master.json