### PR TITLE
Update trident-master.json

### DIFF
--- a/trident-master.json
+++ b/trident-master.json
@@ -174,6 +174,7 @@
 	"audio_denemo_UNSET=GTK2",
 	"audio_gmusicbrowser_SET=GSTREAMER",
 	"audio_grip_SET=FAAC FLAC GOGO",
+	"audio_mous_SET=SNDIO",      
 	"audio_mp3info_SET=GTK2",
 	"audio_musicpd_SET=AAC HTTPD LAME SHOUTCAST",
 	"audio_openal-soft_SET=PORTAUDIO OSS SNDIO",

--- a/trident-master.json
+++ b/trident-master.json
@@ -174,7 +174,7 @@
 	"audio_denemo_UNSET=GTK2",
 	"audio_gmusicbrowser_SET=GSTREAMER",
 	"audio_grip_SET=FAAC FLAC GOGO",
-	"audio_mous_SET=SNDIO",      
+	"audio_mous_UNSET=SNDIO",      
 	"audio_mp3info_SET=GTK2",
 	"audio_musicpd_SET=AAC HTTPD LAME SHOUTCAST",
 	"audio_openal-soft_SET=PORTAUDIO OSS SNDIO",


### PR DESCRIPTION
to get audio/mous to compile

"audio_mous_SET=SNDIO",

=======================<phase: check-sanity   >============================
===>  License BSD2CLAUSE accepted by the user
====> You cannot select multiple options from the OUTPUT_PLUGIN radio
=====> Only one of these must be defined: OSS SNDIO
*** Error code 1